### PR TITLE
Expand test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.4.4
+  - 2.5.3
 env:
   global:
-    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
+    - PUPPET_GEM_VERSION="~> 6.0"
 matrix:
   fast_finish: true
   include:
@@ -24,6 +24,9 @@ matrix:
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec
+    -
+      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.5
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm: 2.1.9

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 1. [Description](#description)
 2. [Setup - The basics of getting started with k5login_core](#setup)
     * [Beginning with k5login_core](#beginning-with-k5login_core)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Reference - User documentation](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Development - Guide for contributing to the module](#development)
+3. [Reference - User documentation](#reference)
+4. [Limitations - OS compatibility, etc.](#limitations)
+5. [Development - Guide for contributing to the module](#development)
 
 ## Description
 
@@ -32,13 +31,9 @@ file { "/home/name/.k5login":
 }
 ```
 
-## Usage
-
-For details on usage, please see the puppet docs on [k5login](https://puppet.com/docs/puppet/latest/types/k5login.html).
-
 ## Reference
 
-Please see REFERENCE.md for the reference documentation.
+Please see [`REFERENCE.md`](REFERENCE.md) for the reference documentation.
 
 This module is documented using Puppet Strings.
 

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Manage the '.k5login' file for a user.",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-k5login_core",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-k5login_core/blob/master/README.md",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-k5login_core",
   "issues_url": "https://tickets.puppetlabs.com/projects/MODULES",
   "dependencies": [
 


### PR DESCRIPTION
Expand test coverage to include Puppet6. Update README (see MODULES-8182) and project metadata.