### PR TITLE
Doc fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Manage k5login context of files.
 
 To set the `.k5login` file for a user:
 ```
-file { "/home/name/.k5login":
+k5login { "/home/name/.k5login":
   ensure => present,
   mode => '644',
   principals => ['foo@site.com', 'bar@site.com'],


### PR DESCRIPTION
Shouldn't the sample doc be using the `k5login` type rather than the file type?